### PR TITLE
CI: Add upload artifacts workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --release --verbose  
       - name: Run tests
         run: cargo test --verbose
+      - name: Upload client artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: client-${{ matrix.os }}
+          path: |
+            ${{ (matrix.os == 'windows-latest' && 'target/release/client.exe') || 'target/release/client' }}
+      - name: Upload server artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: server-${{ matrix.os }}
+          path: |
+            ${{ (matrix.os == 'windows-latest' && 'target/release/server.exe') || 'target/release/server' }}


### PR DESCRIPTION
This commit adds a new workflow file, `upload-artifacts.yml`, which is responsible for uploading client and server artifacts. The workflow is triggered by a workflow call event with the required input of the operating system. The artifacts are uploaded using the `actions/upload-artifact@v2` action, with different paths based on the operating system specified.