### PR TITLE
doc(readme): add link to rustdoc documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Frakt is a Rust-based project focused on the computation and visualization of fractals. This workspace includes several components, such as clients, servers, and shared libraries.
 
+Our documentation is available [here](https://jabibamman.github.io/frakt/client).
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
Added a hyperlink to the documentation in the README.md file. Now users can easily access the documentation by clicking on the provided link.