### PR TITLE
ci: Add release publishing workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,3 +37,42 @@ jobs:
           name: server-${{ matrix.os }}
           path: |
             ${{ (matrix.os == 'windows-latest' && 'target/release/server.exe') || 'target/release/server' }}
+
+  publish_release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/client-${{ matrix.os }}
+          asset_name: client-${{ matrix.os }}.zip
+          asset_content_type: application/zip
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/server-${{ matrix.os }}
+          asset_name: server-${{ matrix.os }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This commit adds a new workflow to publish releases. The workflow is triggered on push events with tags and downloads all artifacts from the build job. It then creates a release, uploads client and server assets in zip format, and attaches them to the release.
